### PR TITLE
Add support for parameter decorators

### DIFF
--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -19,6 +19,7 @@
     "@types/webpack-bundle-analyzer": "^3.9.2",
     "@types/webpack-dev-server": "^3.11.3",
     "babel-loader": "^8.2.2",
+    "babel-plugin-parameter-decorator": "^1.0.16",
     "copy-webpack-plugin": "^8.1.0",
     "fork-ts-checker-webpack-plugin": "^6.2.0",
     "fs-extra": "^9.1.0",

--- a/packages/bundle/src/configs/node.prod.ts
+++ b/packages/bundle/src/configs/node.prod.ts
@@ -127,6 +127,7 @@ export default async (options: NodeBundleDevOptions) => {
 								],
 								plugins: [
 									["@babel/plugin-proposal-decorators", { legacy: true }], // Handles decorators like those required for tsoa
+									"babel-plugin-parameter-decorator", // Handles parameter decorators like those required for tsoa
 									["@babel/plugin-proposal-class-properties", { loose: true }]
 								]
 							}

--- a/packages/web-api/src/features/Echo/EchoController.ts
+++ b/packages/web-api/src/features/Echo/EchoController.ts
@@ -1,0 +1,10 @@
+import { Request as ERequest } from "express"
+import { Controller, Get, Request, Route } from "@tsoa/runtime"
+
+@Route("echo")
+export class EchoController extends Controller {
+	@Get()
+	public async echo(@Request() request: ERequest) {
+		return { message: request.body }
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1887,6 +1887,11 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
+babel-plugin-parameter-decorator@^1.0.16:
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/babel-plugin-parameter-decorator/-/babel-plugin-parameter-decorator-1.0.16.tgz#1c889c3a1f3bbf03801fcbc2e95b8bae7468df3f"
+  integrity sha512-yUT2WPTUg1JaPmRGRSF557m1HJ9vdFQInRWOkiOyO5a9HhqlXffJu+fQ2xd5+qU/35ICMrrk9eWKsHCairKA9w==
+
 babel-plugin-polyfill-corejs2@^0.1.4:
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.1.10.tgz#a2c5c245f56c0cac3dbddbf0726a46b24f0f81d1"


### PR DESCRIPTION
TSOA can inject certain objects into the controller functions, such as Request, Query, and more, as explained here: [https://tsoa-community.github.io/docs/decorators.html](https://tsoa-community.github.io/docs/decorators.html)

I have added `babel-plugin-parameter-decorator` to dev dependencies and utilized it in the node webpack plugins option, as well as added an `EchoController` which uses the `@Request` decorator.

Without this plugin, you will get errors such as these when trying to use `@Request`:

```
ERROR in ./src/features/Echo/EchoController.ts 8:13
Module parse failed: Unexpected character '@' (8:13)
File was processed with these loaders:
 * ../../node_modules/babel-loader/lib/index.js
You may need an additional loader to handle the result of these loaders.
| import { Controller, Get, Request, Route } from "@tsoa/runtime";
| export let EchoController = (_dec = Route("echo"), _dec2 = Get(), _dec(_class = (_class2 = class EchoController extends Controller {
>   async echo(@Request()
|   request) {
|     return {
 @ ./src/routes/routes.ts 7:0-67 40:27-41
 @ ./src/index.ts 9:0-47 19:2-16
```