### PR TITLE
Add support for Typescript const enums in webpack build

### DIFF
--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -18,6 +18,7 @@
     "@types/webpack-bundle-analyzer": "^4.4.0",
     "@types/webpack-dev-server": "^3.11.4",
     "babel-loader": "^8.2.2",
+    "babel-plugin-const-enum": "^1.0.1",
     "babel-plugin-parameter-decorator": "^1.0.16",
     "copy-webpack-plugin": "^9.0.0",
     "fork-ts-checker-webpack-plugin": "^6.2.10",

--- a/packages/bundle/src/configs/node.prod.ts
+++ b/packages/bundle/src/configs/node.prod.ts
@@ -126,6 +126,7 @@ export default async (options: NodeBundleDevOptions) => {
 									]
 								],
 								plugins: [
+									"babel-plugin-const-enum",
 									["@babel/plugin-proposal-decorators", { legacy: true }], // Handles decorators like those required for tsoa
 									"babel-plugin-parameter-decorator", // Handles parameter decorators like those required for tsoa
 									["@babel/plugin-proposal-class-properties", { loose: true }]

--- a/packages/web-api/src/features/Enum/EnumController.ts
+++ b/packages/web-api/src/features/Enum/EnumController.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Route } from "@tsoa/runtime"
+import { Test } from "../../types/constEnumTest"
+
+@Route("_enum")
+export class EnumController extends Controller {
+	@Get()
+	public async enum() {
+
+		const enumTest = Test.a
+
+		await new Promise((res) => setTimeout(res, 1000))
+		return { ok: true, enum: enumTest }
+	}
+}

--- a/packages/web-api/src/types/constEnumTest.ts
+++ b/packages/web-api/src/types/constEnumTest.ts
@@ -1,0 +1,4 @@
+export const enum Test {
+    a = 1,
+    b = 2
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -726,7 +726,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-typescript@^7.14.5":
+"@babel/plugin-syntax-typescript@^7.14.5", "@babel/plugin-syntax-typescript@^7.3.3":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz#b82c6ce471b165b5ce420cf92914d6fb46225716"
   integrity sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==
@@ -2315,6 +2315,14 @@ babel-loader@^8.2.2:
     loader-utils "^1.4.0"
     make-dir "^3.1.0"
     schema-utils "^2.6.5"
+
+babel-plugin-const-enum@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-const-enum/-/babel-plugin-const-enum-1.0.1.tgz#0d742faf9731be4f213c4d01d61fc4e93c44d159"
+  integrity sha512-6oGu63g1FS9psUPQyLCJM08ty6kGihGKTbzWGbAKHfUuCzCh7y9twh516cR6v0lM4d4NOoR+DgLb7uKVytyp6Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-typescript" "^7.3.3"
 
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"


### PR DESCRIPTION
Add `babel-plugin-const-enum` module to make babel able to use Typescript const enums.

In `node.prod.ts`:
![image](https://user-images.githubusercontent.com/1131968/123704642-2ab99000-d866-11eb-846b-26654cd3dd16.png)

produces:
![image](https://user-images.githubusercontent.com/1131968/123704746-4a50b880-d866-11eb-86ad-3e7830e36dd2.png)
when trying to use `const enum` anywhere in an imported path

After adding `babel-plugin-const-enum` as a dev dependency, and adding it to the webpack configuration as a plugin, the project builds fine.

`EnumController` produces `{"ok":true,"enum":1}` after patch.
